### PR TITLE
Migrates SequenceGen to stratgy pattern

### DIFF
--- a/app/src/main/java/com/scrumptious/algorithmvisualizer/BubbleSort.kt
+++ b/app/src/main/java/com/scrumptious/algorithmvisualizer/BubbleSort.kt
@@ -1,11 +1,11 @@
 package com.scrumptious.algorithmvisualizer
 
-class BubbleSortSequenceGenerator{
-    var result = mutableListOf<Pair<Array<Int>, Array<Int>>>()
+class BubbleSort : SequenceStrategy{
 
-    fun sequenceGenerator(inputArr: Array<Int>){
-        val n = inputArr.size
-        val sortArr = inputArr.copyOf()
+    override fun BuildSequence(myData: Array<Int>) : MutableList<Pair<Array<Int>, Array<Int>>>{
+        val result = mutableListOf<Pair<Array<Int>, Array<Int>>>()
+        val n = myData.size
+        val sortArr = myData.copyOf()
 
         for (i in 0 until n - 1) {
             var swapped = false
@@ -23,6 +23,7 @@ class BubbleSortSequenceGenerator{
                 break
             }
         }
+        return result
     }
 }
 

--- a/app/src/main/java/com/scrumptious/algorithmvisualizer/BubbleSort.kt
+++ b/app/src/main/java/com/scrumptious/algorithmvisualizer/BubbleSort.kt
@@ -2,7 +2,7 @@ package com.scrumptious.algorithmvisualizer
 
 class BubbleSort : SequenceStrategy{
 
-    override fun BuildSequence(myData: Array<Int>) : MutableList<Pair<Array<Int>, Array<Int>>>{
+    override fun buildSequence(myData: Array<Int>) : MutableList<Pair<Array<Int>, Array<Int>>>{
         val result = mutableListOf<Pair<Array<Int>, Array<Int>>>()
         val n = myData.size
         val sortArr = myData.copyOf()

--- a/app/src/main/java/com/scrumptious/algorithmvisualizer/InsertionSort.kt
+++ b/app/src/main/java/com/scrumptious/algorithmvisualizer/InsertionSort.kt
@@ -2,7 +2,7 @@ package com.scrumptious.algorithmvisualizer
 
 class InsertionSort: SequenceStrategy{
     //var result = mutableListOf<Pair<Array<Int>, Array<Int>>>()
-    override fun BuildSequence(myData: Array<Int>): MutableList<Pair<Array<Int>, Array<Int>>>{
+    override fun buildSequence(myData: Array<Int>): MutableList<Pair<Array<Int>, Array<Int>>>{
         val result = mutableListOf<Pair<Array<Int>, Array<Int>>>()
         result.add( Pair(myData.copyOf(), emptyArray()))
 

--- a/app/src/main/java/com/scrumptious/algorithmvisualizer/InsertionSort.kt
+++ b/app/src/main/java/com/scrumptious/algorithmvisualizer/InsertionSort.kt
@@ -1,26 +1,26 @@
 package com.scrumptious.algorithmvisualizer
 
-class InsertionSortSeqGen{
-    var result = mutableListOf<Pair<Array<Int>, Array<Int>>>()
-    fun generateSeq(arr: Array<Int>){
-        result = mutableListOf()
-        result.add( Pair(arr.copyOf(), emptyArray()))
+class InsertionSort: SequenceStrategy{
+    //var result = mutableListOf<Pair<Array<Int>, Array<Int>>>()
+    override fun BuildSequence(myData: Array<Int>): MutableList<Pair<Array<Int>, Array<Int>>>{
+        val result = mutableListOf<Pair<Array<Int>, Array<Int>>>()
+        result.add( Pair(myData.copyOf(), emptyArray()))
 
-        if(arr.isEmpty()) return
+        if(myData.isEmpty()) return result
 
-        for(i in 1..<arr.size){
+        for(i in 1..<myData.size){
             var j = i
 
-            while (j > 0 && arr[j] < arr[j - 1]) {
+            while (j > 0 && myData[j] < myData[j - 1]) {
                 //swap(arr, j, j - 1)
-                val temp = arr[j]
-                arr[j] = arr[j-1]
-                arr[j-1] = temp
-                result.add(Pair(arr.copyOf(), arrayOf(j,j-1)))
+                val temp = myData[j]
+                myData[j] = myData[j-1]
+                myData[j-1] = temp
+                result.add(Pair(myData.copyOf(), arrayOf(j,j-1)))
                 j--
             }
         }
-
+        return result
     }
 }
 

--- a/app/src/main/java/com/scrumptious/algorithmvisualizer/SelectionSort.kt
+++ b/app/src/main/java/com/scrumptious/algorithmvisualizer/SelectionSort.kt
@@ -3,7 +3,7 @@ package com.scrumptious.algorithmvisualizer
 
 class SelectionSort : SequenceStrategy {
 
-    override fun BuildSequence(myData: Array<Int>): MutableList<Pair<Array<Int>, Array<Int>>> {
+    override fun buildSequence(myData: Array<Int>): MutableList<Pair<Array<Int>, Array<Int>>> {
         val result = mutableListOf<Pair<Array<Int>, Array<Int>>>()
         val steps = mutableListOf(myData.copyOf()) // Initialize the steps array with the initial state
 

--- a/app/src/main/java/com/scrumptious/algorithmvisualizer/SelectionSort.kt
+++ b/app/src/main/java/com/scrumptious/algorithmvisualizer/SelectionSort.kt
@@ -1,41 +1,40 @@
 package com.scrumptious.algorithmvisualizer
 
 
-class SelectionSortSequenceGen {
+class SelectionSort : SequenceStrategy {
 
-    var result = mutableListOf<Pair<Array<Int>, Array<Int>>>()
+    override fun BuildSequence(myData: Array<Int>): MutableList<Pair<Array<Int>, Array<Int>>> {
+        val result = mutableListOf<Pair<Array<Int>, Array<Int>>>()
+        val steps = mutableListOf(myData.copyOf()) // Initialize the steps array with the initial state
 
-fun selectionSortSequenceGenerator(arr: Array<Int>): Unit {
-    val steps = mutableListOf(arr.copyOf()) // Initialize the steps array with the initial state
+        if (myData.isEmpty()) {
+            return result
+        }
 
-    if (arr.isEmpty()) {
-        return
-    }
+        for (i in 0 until myData.size - 1) {
+            var minIndex = i
+            val swaps = mutableListOf<Int>()
 
-    for (i in 0 until arr.size - 1) {
-        var minIndex = i
-        val swaps = mutableListOf<Int>()
-
-        for (j in i + 1 until arr.size) {
-            if (arr[j] < arr[minIndex]) {
-                minIndex = j
+            for (j in i + 1 until myData.size) {
+                if (myData[j] < myData[minIndex]) {
+                    minIndex = j
+                }
             }
+
+            if (minIndex != i) {
+                val temp = myData[i]
+                myData[i] = myData[minIndex]
+                myData[minIndex] = temp
+
+                swaps.add(i)
+                swaps.add(minIndex)
+            }
+
+            steps.add(myData.copyOf()) // Store the current state in the steps array
+            result.add(Pair(steps.last().copyOf(), swaps.toTypedArray()))
         }
-
-        if (minIndex != i) {
-            val temp = arr[i]
-            arr[i] = arr[minIndex]
-            arr[minIndex] = temp
-
-            swaps.add(i)
-            swaps.add(minIndex)
-        }
-
-        steps.add(arr.copyOf()) // Store the current state in the steps array
-        result.add(Pair(steps.last().copyOf(), swaps.toTypedArray()))
+        return result
     }
-    return
-}
 }
 
 /*

--- a/app/src/main/java/com/scrumptious/algorithmvisualizer/SequenceGenerator.kt
+++ b/app/src/main/java/com/scrumptious/algorithmvisualizer/SequenceGenerator.kt
@@ -3,9 +3,11 @@ package com.scrumptious.algorithmvisualizer
 class SequenceGenerator {
     // Optionally we could choose to store the return in a property here in this class
 
-    private lateinit var strategy : SequenceStrategy
-    fun buildSequence(myData:Array<Int>) = strategy.BuildSequence(myData)
+    //Canonical implementation would have required the following:
+    //private lateinit var strategy : SequenceStrategy
+    //fun setStrategy(newStrategy: SequenceStrategy) { strategy = newStrategy}
+    //However, to avoid the possibility of an uninitialized strategy call being used it has become:
+    fun buildSequence(strategy : SequenceStrategy, myData:Array<Int>) = strategy.buildSequence(myData)
 
-    fun setStrategy(newStrategy: SequenceStrategy) { strategy = newStrategy}
 
 }

--- a/app/src/main/java/com/scrumptious/algorithmvisualizer/SequenceGenerator.kt
+++ b/app/src/main/java/com/scrumptious/algorithmvisualizer/SequenceGenerator.kt
@@ -1,0 +1,11 @@
+package com.scrumptious.algorithmvisualizer
+
+class SequenceGenerator {
+    // Optionally we could choose to store the return in a property here in this class
+
+    private lateinit var strategy : SequenceStrategy
+    fun buildSequence(myData:Array<Int>) = strategy.BuildSequence(myData)
+
+    fun setStrategy(newStrategy: SequenceStrategy) { strategy = newStrategy}
+
+}

--- a/app/src/main/java/com/scrumptious/algorithmvisualizer/SequenceStrategy.kt
+++ b/app/src/main/java/com/scrumptious/algorithmvisualizer/SequenceStrategy.kt
@@ -1,0 +1,7 @@
+package com.scrumptious.algorithmvisualizer
+
+interface SequenceStrategy {
+    fun BuildSequence(myData: Array<Int>) : MutableList<Pair<Array<Int>, Array<Int>>>
+}
+
+

--- a/app/src/main/java/com/scrumptious/algorithmvisualizer/SequenceStrategy.kt
+++ b/app/src/main/java/com/scrumptious/algorithmvisualizer/SequenceStrategy.kt
@@ -1,7 +1,7 @@
 package com.scrumptious.algorithmvisualizer
 
 interface SequenceStrategy {
-    fun BuildSequence(myData: Array<Int>) : MutableList<Pair<Array<Int>, Array<Int>>>
+    fun buildSequence(myData: Array<Int>) : MutableList<Pair<Array<Int>, Array<Int>>>
 }
 
 


### PR DESCRIPTION
Not comprehensively tested.

Current comments:

-  You must SetStrategy before you can use it correctly. Can be fixed by abandoning canonical pattern and instead using a strategy as an argument to buildSequence such that it becomes:

```
    fun buildSequence(strategy : SequenceStrategy, myData:Array<Int>) = strategy.buildSequence(myData)
```